### PR TITLE
Implement support for diff links

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,10 +5,10 @@ build:
 	swift build -c release --disable-sandbox
 
 install: build
-	install ".build/release/git-changelog" "$(bindir)"
+	install ".build/release/git-cl" "$(bindir)"
 
 uninstall:
-	rm -rf "$(bindir)/git-changelog"
+	rm -rf "$(bindir)/git-cl"
 
 clean:
 	rm -rf .build

--- a/Sources/git-cl/GitChangelog.swift
+++ b/Sources/git-cl/GitChangelog.swift
@@ -102,7 +102,8 @@ public final class GitChangelog {
             }
         }
         
-        print(self.markdown.generate(.both, from: self.changelog))
+        let markdown = try self.markdown.generate(.both, from: self.changelog, with: self.git.findRespoitoryOriginURL())
+        print(markdown)
     }
 }
 

--- a/Sources/git-cl/GitShell.swift
+++ b/Sources/git-cl/GitShell.swift
@@ -145,6 +145,13 @@ public class GitShell {
             return nil
         }
     }
+    
+    public func findRespoitoryOriginURL() throws -> URL? {
+        let result = try run(self.path, arguments: ["remote", "get-url", "origin"])
+        guard result.isSuccessful == true else { return nil }
+        guard let output = result.standardOutput else { return nil }
+        return URL(string: String(output.dropLast(5)))
+    }
 }
 
 fileprivate func directoryExists(atPath path: String) -> Bool {


### PR DESCRIPTION
This implements diff links to the repository from the origin url. This
bring this up to spec with the keepachangelog.com

[changelog]
added: Added Diff Links to the bottom of the markdown file

ps-id: 155DA5E3-5D46-4B26-83D4-945C7C06E765

This closes #1 