### PR TITLE
Refactor unreleased to use ChangelogCommits sequence

### DIFF
--- a/Sources/git-cl/Actions/ChangelogCommits.swift
+++ b/Sources/git-cl/Actions/ChangelogCommits.swift
@@ -1,0 +1,73 @@
+import Foundation
+
+public struct ChangelogCommits: Sequence {
+    let commits: Commits
+
+    public func makeIterator() -> ChangelogCommitsIterator {
+        return ChangelogCommitsIterator(self)
+    }
+}
+
+public struct ChangelogCommitsIterator: IteratorProtocol {
+    private let changelogCommits: ChangelogCommits
+    private var commitsIterator: CommitsIterator
+    private let regexPattern = #"(added|changed|deprecated|removed|fixed|security|release):\w?(.*)"#
+
+    init(_ changelogCommits: ChangelogCommits) {
+        self.changelogCommits = changelogCommits
+        self.commitsIterator = changelogCommits.commits.makeIterator()
+    }
+
+    public mutating func next() -> ChangelogCommit? {
+        if let commit = self.commitsIterator.next() {
+            guard let body = commit.body else {
+                return ChangelogCommit(commit: commit, changelogEntries: [])
+            }
+
+            let changelogBody = body
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+                .components(separatedBy: "[changelog]")
+                .dropFirst()
+                .joined(separator: "\n")
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            let regex = try! NSRegularExpression(pattern: self.regexPattern, options: [])
+
+            var changelogEntries: [ChangelogEntry] = []
+
+            let nsrange = NSRange(changelogBody.startIndex..<changelogBody.endIndex, in: changelogBody)
+            regex.enumerateMatches(in: changelogBody, options: [], range: nsrange) { match, _, stop in
+                guard let match = match else { return }
+
+                if match.numberOfRanges == 3 {
+                    guard let firstCaptureRange = Range(match.range(at: 1), in: changelogBody),
+                        let secondCaptureRange = Range(match.range(at: 2), in: changelogBody) else { return }
+
+                    let category = changelogBody[firstCaptureRange].trimmingCharacters(in: .whitespacesAndNewlines)
+                    let message = changelogBody[secondCaptureRange].trimmingCharacters(in: .whitespacesAndNewlines)
+
+                    switch category {
+                    case "release":
+                        changelogEntries.append(ChangelogEntry.release(message))
+                    case "added":
+                        changelogEntries.append(ChangelogEntry.added(message))
+                    case "changed":
+                        changelogEntries.append(ChangelogEntry.changed(message))
+                    case "deprecated":
+                        changelogEntries.append(ChangelogEntry.deprecated(message))
+                    case "removed":
+                        changelogEntries.append(ChangelogEntry.removed(message))
+                    case "fixed":
+                        changelogEntries.append(ChangelogEntry.fixed(message))
+                    case "security":
+                        changelogEntries.append(ChangelogEntry.security(message))
+                    default:
+                        return
+                    }
+                }
+            }
+            return ChangelogCommit(commit: commit, changelogEntries:changelogEntries)
+        } else {
+            return nil
+        }
+    }
+}

--- a/Sources/git-cl/Commit.swift
+++ b/Sources/git-cl/Commit.swift
@@ -1,13 +1,5 @@
 import Foundation
 
-public struct Commit {
-    public let sha: String
-    public let date: Date
-    public let summary: String
-    public let body: String?
-}
-
-
 extension Commit: CustomStringConvertible {
     public var description: String {
         return "\(self.sha.prefix(6)) \(self.summary)"

--- a/Sources/git-cl/GitShell.swift
+++ b/Sources/git-cl/GitShell.swift
@@ -1,5 +1,12 @@
 import Foundation
 
+public struct Commit {
+    public let sha: String
+    public let date: Date
+    public let summary: String
+    public let body: String?
+}
+
 public struct Commits: Sequence {
     let formattedGitLogOutput: String
 

--- a/Sources/git-cl/Models/ChangelogCommit.swift
+++ b/Sources/git-cl/Models/ChangelogCommit.swift
@@ -1,0 +1,6 @@
+import Foundation
+
+public struct ChangelogCommit {
+    public let commit: Commit
+    public let changelogEntries: [ChangelogEntry]
+}

--- a/Sources/git-cl/Models/ChangelogEntry.swift
+++ b/Sources/git-cl/Models/ChangelogEntry.swift
@@ -1,0 +1,36 @@
+import Foundation
+
+public enum ChangelogEntry {
+    case release(String)
+    case added(String)
+    case changed(String)
+    case deprecated(String)
+    case removed(String)
+    case fixed(String)
+    case security(String)
+
+    public var typeString: String {
+        switch self {
+        case .added: return "added"
+        case .changed: return "changed"
+        case .deprecated: return "deprecated"
+        case .fixed: return "fixed"
+        case .release: return "release"
+        case .removed: return "removed"
+        case .security: return "security"
+        }
+    }
+
+    public var message: String {
+        switch self {
+        case .added(let msg): return msg
+        case .changed(let msg): return msg
+        case .deprecated(let msg): return msg
+        case .fixed(let msg): return msg
+        case .release(let msg): return msg
+        case .removed(let msg): return msg
+        case .security(let msg): return msg
+        }
+
+    }
+}


### PR DESCRIPTION
I did this because it should be more performant as it only processes and
parses the commits that it needs to.

This does this by introducing a new ChangelogCommits sequence type that
exposes a ChangelogCommit type that includes a new concept of
ChangelogEntry.

[changlog]
changed: improved performance of unreleased sub-command

ps-id: A6C91CCB-3666-4AF7-9652-7DF276A5D3DF