### PR TITLE
Add the `latest` sub-command

### DIFF
--- a/Sources/git-cl/Commands/GitChangelog.swift
+++ b/Sources/git-cl/Commands/GitChangelog.swift
@@ -8,7 +8,7 @@ public class GitChangelog: ParsableCommand {
             abstract: "Git Changelog Generation",
             discussion: "Generates a CHANGELOG.md compatible file based on changelog entries in your git commits.",
             version: VERSION.description,
-            subcommands: [FullCommand.self, UnreleasedCommand.self, ReleasedCommand.self]
+            subcommands: [LatestCommand.self, FullCommand.self, UnreleasedCommand.self, ReleasedCommand.self]
         )
     }
     

--- a/Sources/git-cl/Commands/Helpers.swift
+++ b/Sources/git-cl/Commands/Helpers.swift
@@ -1,0 +1,24 @@
+import Foundation
+
+extension Dictionary where Key == Changelog.Category, Value == [Changelog.Entry] {
+    public mutating func upsertAppend(value: Changelog.Entry, for key: Changelog.Category) {
+        if let _ = self[key] {
+            self[key]!.append(value)
+        } else {
+            self[key] = [value]
+        }
+    }
+}
+
+func markdown(_ categorizedEntries: [Changelog.Category: [Changelog.Entry]]) -> String {
+    var result = ""
+    categorizedEntries.forEach { category, entries in
+        result += "\n### \(category.capitalized)\n"
+        entries.forEach { result += "- \($0)\n" }
+    }
+    return result
+}
+
+func commitSummary(_ changelogCommit: ChangelogCommit) -> String {
+    return "\(changelogCommit.commit.sha.prefix(6)) \(changelogCommit.commit.summary)"
+}


### PR DESCRIPTION
I did this so that users would be able to just get the latest release
information or latest release commits easily.

[changelog]
added: latest sub-command to allow users to get the latest release info

ps-id: CA49DF04-A3DD-4954-B600-5651B3DC86A1