### PR TITLE
Fix up the diff links

### DIFF
--- a/Sources/git-cl/Actions/ChangelogAction.swift
+++ b/Sources/git-cl/Actions/ChangelogAction.swift
@@ -4,8 +4,6 @@ import ArgumentParser
 class ChangelogAction {
     private let git: GitShell
     private let markdown: MarkdownAction
-    private var changelog: Changelog = Changelog()
-    private var currentReleaseID: Changelog.ReleaseID?
     private let regexPattern = #"(added|changed|deprecated|removed|fixed|security|release):\w?(.*)"#
     
     var releasedCommits: [Commit] = []
@@ -18,62 +16,49 @@ class ChangelogAction {
     
     @discardableResult
     func parse() throws -> Changelog {
-        for commit in try self.git.commits() {
-            guard let body = commit.body else { continue }
-            
-            let changelogBody = body
-                .trimmingCharacters(in: .whitespacesAndNewlines)
-                .components(separatedBy: "[changelog]")
-                .dropFirst()
-                .joined(separator: "\n")
-                .trimmingCharacters(in: .whitespacesAndNewlines)
-            let regex = try NSRegularExpression(pattern: self.regexPattern, options: [])
-            
-            let nsrange = NSRange(changelogBody.startIndex..<changelogBody.endIndex, in: changelogBody)
-            regex.enumerateMatches(in: changelogBody, options: [], range: nsrange) { match, _, stop in
-                guard let match = match else { return }
-                
-                if match.numberOfRanges == 3 {
-                    guard let firstCaptureRange = Range(match.range(at: 1), in: changelogBody),
-                        let secondCaptureRange = Range(match.range(at: 2), in: changelogBody) else { return }
-                    
-                    let category = changelogBody[firstCaptureRange].trimmingCharacters(in: .whitespacesAndNewlines)
-                    let message = changelogBody[secondCaptureRange].trimmingCharacters(in: .whitespacesAndNewlines)
-                    
-                    switch category {
-                    case "release":
-                        self.currentReleaseID = message
-                        self.changelog.releases[self.currentReleaseID!] = Changelog.Release(date: commit.date, id: currentReleaseID!, categorizedEntries: [:])
-                        if !self.releasedCommits.contains(where: { $0.sha == commit.sha }) {
-                            self.releasedCommits.append(commit)
-                        }
-                    default:
-                        if let releaseID = currentReleaseID {
-                            if let _ = self.changelog.releases[releaseID]!.categorizedEntries[category] {
-                                self.changelog.releases[releaseID]!.categorizedEntries[category]!.append(message)
-                            } else {
-                                self.changelog.releases[releaseID]!.categorizedEntries[category] = [message]
-                            }
-                            if !self.releasedCommits.contains(where: { $0.sha == commit.sha }) {
-                                self.releasedCommits.append(commit)
-                            }
+        var currentRelease: String?
+        let changelog = Changelog()
+        let commits = try ChangelogCommits(commits: self.git.commits())
+        for commit in commits {
+            for changelogEntry in commit.changelogEntries {
+                switch changelogEntry {
+                case .release(let release):
+                    currentRelease = release
+                    let entry = Changelog.Entry()
+                    entry.commitSha = commit.commit.sha
+                    entry.version = release
+                    entry.date = commit.commit.date
+                    changelog.releases.append(entry)
+                    if !self.releasedCommits.contains(where: { $0.sha == commit.commit.sha }) {
+                        self.releasedCommits.append(commit.commit)
+                    }
+                default:
+                    if let releaseId = currentRelease, let release = changelog.releases.first(where: { $0.version == releaseId }) {
+                        if var entries = release.entries[changelogEntry.typeString.capitalized] {
+                            entries.append(changelogEntry.message)
+                            release.entries[changelogEntry.typeString.capitalized] = entries
                         } else {
-                            if !self.unreleasedCommits.contains(where: { $0.sha == commit.sha }) {
-                                self.unreleasedCommits.append(commit)
-                            }
-                            if let _ = self.changelog.unreleased.categorizedEntries[category] {
-                                self.changelog.unreleased.categorizedEntries[category]!.append(message)
-                            } else {
-                                self.changelog.unreleased.categorizedEntries[category] = [message]
-                            }
+                            release.entries[changelogEntry.typeString.capitalized] = [changelogEntry.message]
+                        }
+                        if !self.releasedCommits.contains(where: { $0.sha == commit.commit.sha }) {
+                            self.releasedCommits.append(commit.commit)
+                        }
+                    } else {
+                        if !self.unreleasedCommits.contains(where: { $0.sha == commit.commit.sha }) {
+                            self.unreleasedCommits.append(commit.commit)
+                        }
+                        if let _ = changelog.unreleased.entries[changelogEntry.typeString] {
+                            changelog.unreleased.entries[changelogEntry.typeString]!.append(changelogEntry.message)
+                        } else {
+                            changelog.unreleased.entries[changelogEntry.typeString] = [changelogEntry.message]
                         }
                     }
                 }
             }
         }
-        return self.changelog
+        return changelog
     }
-    
+         
     func repositoryURL() throws -> URL? {
         return try self.git.findRespoitoryOriginURL()
     }

--- a/Sources/git-cl/Actions/MarkdownAction.swift
+++ b/Sources/git-cl/Actions/MarkdownAction.swift
@@ -25,7 +25,7 @@ public class MarkdownAction {
     
     init() { }
     
-    public func generate(_ type: ChangelogType, from changelog: Changelog, with url: URL?) -> String {
+    public func generate(_ type: ChangelogType, from changelog: OldChangelog, with url: URL?) -> String {
         var result = self.markdownChanglogBase
         switch type {
         case .both:
@@ -38,17 +38,18 @@ public class MarkdownAction {
         case .released:
             result += self.generateReleased(from: changelog)
         }
-        // Generate the diff links for everything other than the unreleased changes
-        if type != .unreleased {
+        
+        // Generate the diff links for both unreleased and released (full markdown file)
+        if type == .both {
             if let url = url {
-                result +=  self.generateVersionDiffs(from: changelog, with: url)
+                result += self.generateVersionDiffs(from: changelog, with: url)
             }
         }
         return result
     }
     
-    public func generateUnreleased(from changelog: Changelog) -> String {
-        var result = "\n\n## Unreleased - now\n"
+    public func generateUnreleased(from changelog: OldChangelog) -> String {
+        var result = "\n\n## [Unreleased] - now\n"
         
         changelog.unreleased.categorizedEntries.forEach { category, entries in
             result += "\n### \(category.capitalized)\n"
@@ -58,11 +59,11 @@ public class MarkdownAction {
         return result
     }
     
-    public func generateReleased(from changelog: Changelog) -> String {
+    public func generateReleased(from changelog: OldChangelog) -> String {
         var result = ""
         
         changelog.releases.sorted(by: { $0.key > $1.key }).forEach { releaseID, release in
-            result += "\n\n## \(releaseID) - \(self.dateFormatter.string(from: release.date))\n"
+            result += "\n\n## [\(releaseID)] - \(self.dateFormatter.string(from: release.date))\n"
             release.categorizedEntries.forEach { (category, entries) in
                 result += "\n### \(category.capitalized)\n"
                 entries.forEach { result += "- \($0)\n" }
@@ -72,7 +73,7 @@ public class MarkdownAction {
         return result
     }
     
-    public func generateRelease(from changelog: Changelog, for release: String) -> String {
+    public func generateRelease(from changelog: OldChangelog, for release: String) -> String {
         guard let changelogRelease = changelog.releases[release] else {
             return "No changelog found"
         }
@@ -87,34 +88,33 @@ public class MarkdownAction {
         return result
     }
     
-    func generateVersionDiffs(from changelog: Changelog, with url: URL) -> String {
-        var result = "\n\n"
-        let sortedReleases = changelog.releases.sorted(by: { $0.key > $1.key })
-        for index in 0..<sortedReleases.count {
-            // If it's the first index, we need to set it as un-released
-            if index == 0 {
-                let release = sortedReleases[index]
-                let ref = url.absoluteString + "/compare/\(release.key)...HEAD"
-                result += "[Unreleased]: \(ref)\n"
-                continue
-            }
-            
-            // If it's the last release, we need to set the tag
-            if index == sortedReleases.count - 1 {
-                let release = sortedReleases[index]
-                let ref = url.absoluteString + "/releases/tag/\(release.key)"
-                result += "[\(release.key)]: \(ref)\n"
-                continue
-            }
-            
-            // Check if our index is in range
-            if index - 1 >= 0 {
-                let release = sortedReleases[index]
-                let previousRelease = sortedReleases[index - 1]
-                let ref = url.absoluteString + "/compare/\(release.key)...\(previousRelease.key)"
-                result += "[\(release.key)]: \(ref)\n"
-            }
-        }
+    func generateVersionDiffs(from changelog: OldChangelog, with url: URL) -> String {
+        let result = "\n\n"
+        
+//        let sortedReleases = changelog.releases.sorted(by: { $0.key > $1.key })
+//        var releases = sortedReleases.enumerated().map({ (key: "\($0.element.key)", index: $0.offset + 1) })
+//        releases.insert((key: "Unreleased", index: 0), at: 0)
+//        
+//        for (key, index) in releases {
+//            let previousIndex = index > 0 ? index - 1 : 0
+//            // If the index is 0 and the releases contains only 1 release, we dont generate the diff links
+//            if index == 0 && index == releases.count - 1 {
+//                result = ""
+//                continue
+//            }
+//            
+//            // The first index will always be the unreleased section
+//            if index == 0 {
+//                result += "[\(key)]: \(url.absoluteString + "/compare/\(sortedReleases[previousIndex].key)...HEAD")\n"
+//                continue
+//            }
+//            
+//            if index == releases.count - 1 {
+//                result += "[\(key)]: \(url.absoluteString + "/releases/tag/\(key)")\n"
+//            } else {
+//                result += "[\(key)]: \(url.absoluteString + "/compare/\(sortedReleases[index].key)...\(key)")\n"
+//            }
+//        }
         
         return result
     }

--- a/Sources/git-cl/Commands/FullCommand.swift
+++ b/Sources/git-cl/Commands/FullCommand.swift
@@ -2,6 +2,9 @@ import Foundation
 import ArgumentParser
 
 struct FullCommand: ParsableCommand {
+    private let git: GitShell
+    private let changelogCommits: ChangelogCommits
+
     static var configuration: CommandConfiguration {
         return .init(
             commandName: "full",
@@ -14,20 +17,88 @@ struct FullCommand: ParsableCommand {
     let markdownAction = MarkdownAction()
     
     init() {
-        
+        self.git = try! GitShell(bash: Bash())
+        self.changelogCommits = try! ChangelogCommits(commits: self.git.commits())
     }
     
     init(from decoder: Decoder) throws {
-        
+        self.git = try! GitShell(bash: Bash())
+        self.changelogCommits = try! ChangelogCommits(commits: self.git.commits())
     }
     
     func run() throws {
-        let changes = try self.changelogAction.parse()
-        let markdown = try self.markdownAction.generate(
-            .both,
-            from: changes,
-            with: self.changelogAction.repositoryURL()
-        )
-        print(markdown)
+        var categorizedEntries: [OldChangelog.Category: [OldChangelog.Entry]] = [:]
+        var versionShas: [(String, String, String)] = []
+        var releaseID: String?
+        var releaseDate: Date?
+        var releaseSha: String?
+        var lastSha: String?
+
+        print("""
+        # Changelog
+
+        All notable changes to this project will be documented in this file.
+
+        The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+        and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+        """)
+
+        for changelogCommit: ChangelogCommit in self.changelogCommits {
+            if !changelogCommit.changelogEntries.isEmpty {
+                for entry in changelogCommit.changelogEntries {
+                    switch entry {
+                    case .release(let msg):
+                        // track release shas for generating link references at the end
+                        if let releaseID = releaseID, let _ = releaseDate, let releaseSha = releaseSha {
+                            versionShas.append((releaseID, releaseSha, changelogCommit.commit.sha))
+                        } else { // handle Unreleased
+                            versionShas.append(("Unreleased", "HEAD", changelogCommit.commit.sha))
+                        }
+
+                        // print the previous release or unreleased
+                        if let releaseID = releaseID, let releaseDate = releaseDate, let _ = releaseSha {
+                            print(markdownRelease(releaseID: releaseID, date: releaseDate, categorizedEntries: categorizedEntries, withLinkRef: true))
+                        } else {
+                            print(markdownUnreleased(categorizedEntries, withLinkRef: true))
+                        }
+
+                        // reset the categorizedEntries and associated tracking state
+                        releaseID = msg
+                        releaseDate = changelogCommit.commit.date
+                        releaseSha = changelogCommit.commit.sha
+                        categorizedEntries = [:]
+                    default:
+                        categorizedEntries.upsertAppend(value: entry.message, for: entry.typeString)
+                    }
+                }
+            }
+            lastSha = changelogCommit.commit.sha
+        }
+
+        // track release shas for generating link references at the end
+        if let releaseID = releaseID, let _ = releaseDate, let releaseSha = releaseSha {
+            versionShas.append((releaseID, releaseSha, lastSha!))
+        } else { // handle Unreleased
+            versionShas.append(("Unreleased", "HEAD", lastSha!))
+        }
+
+        // print the previous release or unreleased
+        if let releaseID = releaseID, let releaseDate = releaseDate {
+            print(markdownRelease(releaseID: releaseID, date: releaseDate, categorizedEntries: categorizedEntries, withLinkRef: true))
+        } else {
+            print(markdownUnreleased(categorizedEntries, withLinkRef: true))
+        }
+
+        // print the link references
+        let compareBaseURL = self.repositoryURL()!
+        versionShas.forEach { versionShaInfo in
+            print("[\(versionShaInfo.0)]: \(compareBaseURL.absoluteString)/compare/\(versionShaInfo.2.prefix(7))...\(versionShaInfo.1.prefix(7))")
+        }
+    }
+
+    private func repositoryURL() -> URL? {
+        let urlString = try! self.git.findRespoitoryOriginURL()!.absoluteString
+        return URL(string: urlString.replacingOccurrences(of: ":", with: "/").replacingOccurrences(of: "git@", with: "https://"))
     }
 }

--- a/Sources/git-cl/Commands/Helpers.swift
+++ b/Sources/git-cl/Commands/Helpers.swift
@@ -1,7 +1,7 @@
 import Foundation
 
-extension Dictionary where Key == Changelog.Category, Value == [Changelog.Entry] {
-    public mutating func upsertAppend(value: Changelog.Entry, for key: Changelog.Category) {
+extension Dictionary where Key == OldChangelog.Category, Value == [OldChangelog.Entry] {
+    public mutating func upsertAppend(value: OldChangelog.Entry, for key: OldChangelog.Category) {
         if let _ = self[key] {
             self[key]!.append(value)
         } else {
@@ -10,7 +10,7 @@ extension Dictionary where Key == Changelog.Category, Value == [Changelog.Entry]
     }
 }
 
-func markdown(_ categorizedEntries: [Changelog.Category: [Changelog.Entry]]) -> String {
+func markdown(_ categorizedEntries: [OldChangelog.Category: [OldChangelog.Entry]]) -> String {
     var result = ""
     categorizedEntries.forEach { category, entries in
         result += "\n### \(category.capitalized)\n"
@@ -21,4 +21,21 @@ func markdown(_ categorizedEntries: [Changelog.Category: [Changelog.Entry]]) -> 
 
 func commitSummary(_ changelogCommit: ChangelogCommit) -> String {
     return "\(changelogCommit.commit.sha.prefix(6)) \(changelogCommit.commit.summary)"
+}
+
+func markdownUnreleased(_ categorizedEntries: [OldChangelog.Category: [OldChangelog.Entry]], withLinkRef: Bool = false) -> String {
+    var result = withLinkRef ? "\n## [Unreleased] - now\n" : "\n## Unreleased - now\n"
+    result += markdown(categorizedEntries)
+    return result
+}
+
+func markdownRelease(releaseID: String, date: Date, categorizedEntries: [OldChangelog.Category: [OldChangelog.Entry]], withLinkRef: Bool = false) -> String {
+    let dateFormatter = DateFormatter()
+    dateFormatter.locale = .current
+    dateFormatter.dateFormat = "yyyy-MM-dd"
+
+    var result = ""
+    result += withLinkRef ? "\n## [\(releaseID)] - \(dateFormatter.string(from: date))\n" : "\n## \(releaseID) - \(dateFormatter.string(from: date))\n"
+    result += markdown(categorizedEntries)
+    return result
 }

--- a/Sources/git-cl/Commands/LatestCommand.swift
+++ b/Sources/git-cl/Commands/LatestCommand.swift
@@ -37,7 +37,7 @@ struct LatestCommand: ParsableCommand {
     }
 
     func run() throws {
-        var categorizedEntries: [Changelog.Category: [Changelog.Entry]] = [:]
+        var categorizedEntries: [OldChangelog.Category: [OldChangelog.Entry]] = [:]
         var releaseID: String?
         var releaseDate: Date?
 
@@ -72,15 +72,4 @@ struct LatestCommand: ParsableCommand {
             print(markdownRelease(releaseID: releaseID!, date: releaseDate!, categorizedEntries: categorizedEntries))
         }
     }
-}
-
-func markdownRelease(releaseID: String, date: Date, categorizedEntries: [Changelog.Category: [Changelog.Entry]]) -> String {
-    let dateFormatter = DateFormatter()
-    dateFormatter.locale = .current
-    dateFormatter.dateFormat = "yyyy-MM-dd"
-
-    var result = ""
-    result += "\n\n## \(releaseID) - \(dateFormatter.string(from: date))\n"
-    result += markdown(categorizedEntries)
-    return result
 }

--- a/Sources/git-cl/Commands/ReleasedCommand.swift
+++ b/Sources/git-cl/Commands/ReleasedCommand.swift
@@ -42,10 +42,18 @@ struct ReleasedCommand: ParsableCommand {
         }
         
         let changes = try self.changelogAction.parse()
-        let markdown = self.markdownAction.generateRelease(
-            from: changes,
-            for: release
-        )
-        print(markdown)
+        print(changes)
+//        var markdown = try self.markdownAction.generate(
+//            .released,
+//            from: changes,
+//            with: self.changelogAction.repositoryURL()
+//        )
+//        if let release = release {
+//            markdown = self.markdownAction.generateRelease(
+//                from: changes,
+//                for: release
+//            )
+//        }
+//        print(markdown)
     }
 }

--- a/Sources/git-cl/Commands/UnreleasedCommand.swift
+++ b/Sources/git-cl/Commands/UnreleasedCommand.swift
@@ -37,7 +37,7 @@ struct UnreleasedCommand: ParsableCommand {
     }
     
     func run() throws {
-        var categorizedEntries: [Changelog.Category: [Changelog.Entry]] = [:]
+        var categorizedEntries: [OldChangelog.Category: [OldChangelog.Entry]] = [:]
 
         outerLoop: for changelogCommit: ChangelogCommit in self.changelogCommits {
             if !changelogCommit.changelogEntries.isEmpty {
@@ -61,10 +61,4 @@ struct UnreleasedCommand: ParsableCommand {
             print(markdownUnreleased(categorizedEntries))
         }
     }
-}
-
-func markdownUnreleased(_ categorizedEntries: [Changelog.Category: [Changelog.Entry]]) -> String {
-    var result = "\n\n## Unreleased - now\n"
-    result += markdown(categorizedEntries)
-    return result
 }

--- a/Sources/git-cl/Commit.swift
+++ b/Sources/git-cl/Commit.swift
@@ -1,5 +1,12 @@
 import Foundation
 
+public struct Commit {
+    public let sha: String
+    public let date: Date
+    public let summary: String
+    public let body: String?
+}
+
 extension Commit: CustomStringConvertible {
     public var description: String {
         return "\(self.sha.prefix(6)) \(self.summary)"

--- a/Sources/git-cl/GitShell.swift
+++ b/Sources/git-cl/GitShell.swift
@@ -1,12 +1,5 @@
 import Foundation
 
-public struct Commit {
-    public let sha: String
-    public let date: Date
-    public let summary: String
-    public let body: String?
-}
-
 public struct Commits: Sequence {
     let formattedGitLogOutput: String
 
@@ -128,7 +121,12 @@ public class GitShell {
     public func findRespoitoryOriginURL() throws -> URL? {
         let result = try run(self.path, arguments: ["remote", "get-url", "origin"])
         guard result.isSuccessful == true else { return nil }
-        guard let output = result.standardOutput else { return nil }
+        guard var output = result.standardOutput else { return nil }
+        if output.contains("ssh") {
+            output = output
+                .replacingOccurrences(of: "git@", with: "https://")
+                .replacingOccurrences(of: ":", with: "/")
+        }
         return URL(string: String(output.dropLast(5)))
     }
 }

--- a/Sources/git-cl/Models/Changelog.swift
+++ b/Sources/git-cl/Models/Changelog.swift
@@ -1,16 +1,36 @@
 import Foundation
 
-public struct Changelog: Codable {
+public struct OldChangelog: Codable {
     public typealias Category = String
     public typealias Entry = String
     public typealias ReleaseID = String
 
     public struct Release: Codable {
         public let date: Date
-        public let id: Changelog.ReleaseID
+        public let id: OldChangelog.ReleaseID
         public var categorizedEntries: [Category: [Entry]]
     }
 
     public var unreleased: Release = Release(date: Date(), id: "don't care", categorizedEntries: [:])
     public var releases: [ReleaseID: Release] = [:]
+}
+
+public class Changelog: Codable {
+    public class Entry: Codable {
+        var commitSha: String = ""
+        var version: String = ""
+        var date: Date = Date()
+        var entries: [String: [String]] = [:]
+        
+        init(version: String) {
+            self.version = version
+        }
+        
+        init() {
+            
+        }
+    }
+    
+    var unreleased: Entry = Entry(version: "Unreleased")
+    var releases: [Entry] = []
 }

--- a/Sources/git-cl/Models/ChangelogEntry.swift
+++ b/Sources/git-cl/Models/ChangelogEntry.swift
@@ -31,6 +31,5 @@ public enum ChangelogEntry {
         case .removed(let msg): return msg
         case .security(let msg): return msg
         }
-
     }
 }


### PR DESCRIPTION
This fixes an issue where the `continue` was causing the for loop to
fail.

[changelog]
fixed: Diff links now display all releases and the headers of each section correctly links to the diff.

ps-id: 65A9B70B-BE53-42B8-B35C-621E238124C4

Closes #20 