### PR TITLE
Make `released` sub-command require release-id

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,8 +44,8 @@ After youh ave been recording your CHANGELOG entries you can use `git-cl` to do 
 - `git cl latest` - get the changelog entries of the latest release
 - `git cl latest --commits` - get the commits that are part of the latest release
 - `git cl full` - get a full Markdown CHANGELOG based on [keepachangelog](https://keepachangelog.com/), useful for automating publishing or doing a historical review of a project
-- `git cl released [release-id]` - get changelog entries for the specified release or all the released versions if `release-id` isn't specified
-- `git cl released [released-id] --commits` - get commits included in the specified release or all the released versions if `release-id` isn't specified
+- `git cl released <release-id>` - get changelog entries for the specified release
+- `git cl released <released-id> --commits` - get commits included in the specified release
 
 
 ## Installation

--- a/Sources/git-cl/Commands/ReleasedCommand.swift
+++ b/Sources/git-cl/Commands/ReleasedCommand.swift
@@ -17,9 +17,9 @@ struct ReleasedCommand: ParsableCommand {
     
     @Flag(name: .shortAndLong, help: "Generate a list of released commits")
     var commits: Bool
-    
-    @Option(name: .shortAndLong, help: "The release id")
-    var release: String?
+
+    @Argument(help: "The release id")
+    var release: String
         
     let changelogAction = ChangelogAction()
     let markdownAction = MarkdownAction()
@@ -42,17 +42,10 @@ struct ReleasedCommand: ParsableCommand {
         }
         
         let changes = try self.changelogAction.parse()
-        var markdown = try self.markdownAction.generate(
-            .released,
+        let markdown = self.markdownAction.generateRelease(
             from: changes,
-            with: self.changelogAction.repositoryURL()
+            for: release
         )
-        if let release = release {
-            markdown = self.markdownAction.generateRelease(
-                from: changes,
-                for: release
-            )
-        }
         print(markdown)
     }
 }


### PR DESCRIPTION
We did this because we weren't sure of what the use case was for getting
all of the released changelog entries or commits. Also we couldn't get
Apple's CLI parser lib to properly allow the release id argument to be
optional. It would allow us to set it and report it as optional in the
help. However, when you would run it without that argument it would
error out saying it was missing a required argument. So, since we didn't
think the use case without the release id was valuable we just
eliminated it.

[changelog]
removed: variant of released with no release-id argument

ps-id: 91612DCD-CFC9-4916-8ECF-E5B9AC7F19B4