### PR TITLE
Add tags to Commit

### DIFF
--- a/Sources/git-cl/Commit.swift
+++ b/Sources/git-cl/Commit.swift
@@ -5,6 +5,7 @@ public struct Commit {
     public let date: Date
     public let summary: String
     public let body: String?
+    public let tags: [String]
 }
 
 extension Commit: CustomStringConvertible {


### PR DESCRIPTION
So that we would be able to use tags to identify releases in the future
rather than identifying a release a release via a "release" entry in the
commit. We want to do this because when you cherry pick commits with
"release" entries in the commits it breaks releases. This made us
re-asses and determine that tags are the appropriate thing to determine
releases. Also this has the added benefit of reducing duplicative effort
when cutting a release. It also simplifies things as it will make it so
commits contain changelog entries just for the changes made in them.

ps-id: 69620D7A-537C-4948-9BA1-4BBB88590707