### PR TITLE
Change releases to be identified by tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ We created `git-cl` primarily because of the following:
 
 - conflicts caused by people changing a `CHANGELOG.md` file are **annoying**
 - the audience of a CHANGELOG is different than the audience of your commit messages
-- having the concept of a `release` in a commit message unlocks extremly useful abilities
+- wanted Git tags to identify releases so people don't have to change their release workflow
 
 ## How
 
@@ -16,15 +16,12 @@ You use it on two ends. First you have to record your CHANGELOG entries.
 
 ### Record CHANGELOG Entries
 
-Similar to what you are probably used to with CHANGELOG file formats, with `git-cl` you include single line entries categorized within the following: `release`, `added`, `changed`, `deprecated`, `removed`, `fixed`, `security`. The difference is that you place these entries at the end of your Git commit message body under a section identified via `[changelog]`. 
+Similar to what you are probably used to with CHANGELOG file formats, with `git-cl` you include single line entries categorized within the following: `added`, `changed`, `deprecated`, `removed`, `fixed`, `security`. The difference is that you place these entries at the end of your Git commit message body under a section identified via `[changelog]`. 
 
 The following is an example of the schema. You effectively have a section header of `[changelog]` and then below that you have any of the categorized entries that follow.
 
-*Note:* If you include both a `release` entry as well as other entries. If the other entries are below the `release` entry they will be included as part of that release. If they are above the `release` entry they will be included as part of the Unreleased category.
-
 ```text
 [changelog]
-release: v2.4.8
 added: some addition you made that you want in your changelog
 changed: some change you made that you want in your changelog
 deprecated: some deprecation notice you want in your changelog

--- a/Sources/git-cl/Actions/ChangelogCommits.swift
+++ b/Sources/git-cl/Actions/ChangelogCommits.swift
@@ -11,7 +11,7 @@ public struct ChangelogCommits: Sequence {
 public struct ChangelogCommitsIterator: IteratorProtocol {
     private let changelogCommits: ChangelogCommits
     private var commitsIterator: CommitsIterator
-    private let regexPattern = #"(added|changed|deprecated|removed|fixed|security|release):\w?(.*)"#
+    private let regexPattern = #"(added|changed|deprecated|removed|fixed|security):\w?(.*)"#
 
     init(_ changelogCommits: ChangelogCommits) {
         self.changelogCommits = changelogCommits
@@ -46,8 +46,6 @@ public struct ChangelogCommitsIterator: IteratorProtocol {
                     let message = changelogBody[secondCaptureRange].trimmingCharacters(in: .whitespacesAndNewlines)
 
                     switch category {
-                    case "release":
-                        changelogEntries.append(ChangelogEntry.release(message))
                     case "added":
                         changelogEntries.append(ChangelogEntry.added(message))
                     case "changed":

--- a/Sources/git-cl/Commands/Helpers.swift
+++ b/Sources/git-cl/Commands/Helpers.swift
@@ -10,6 +10,12 @@ extension Dictionary where Key == OldChangelog.Category, Value == [OldChangelog.
     }
 }
 
+extension String {
+    func matches(_ regex: String) -> Bool {
+        return (self.range(of: regex, options: .regularExpression, range: nil, locale: nil) != nil)
+    }
+}
+
 func markdown(_ categorizedEntries: [OldChangelog.Category: [OldChangelog.Entry]]) -> String {
     var result = ""
     categorizedEntries.forEach { category, entries in

--- a/Sources/git-cl/Commands/LatestCommand.swift
+++ b/Sources/git-cl/Commands/LatestCommand.swift
@@ -39,20 +39,19 @@ struct LatestCommand: ParsableCommand {
         var releaseDate: Date?
 
         outerLoop: for changelogCommit: ChangelogCommit in self.changelogCommits {
+            if let release = changelogCommit.release {
+                if releaseID != nil {
+                    break outerLoop
+                } else {
+                    releaseID = release
+                    releaseDate = changelogCommit.commit.date
+                }
+            }
+
             if !changelogCommit.changelogEntries.isEmpty {
                 for entry in changelogCommit.changelogEntries {
-                    switch entry {
-                    case .release(let msg):
-                        if releaseID != nil {
-                            break outerLoop
-                        } else {
-                            releaseID = msg
-                            releaseDate = changelogCommit.commit.date
-                        }
-                    default:
-                        if releaseID != nil {
-                            categorizedEntries.upsertAppend(value: entry.message, for: entry.typeString)
-                        }
+                    if releaseID != nil {
+                        categorizedEntries.upsertAppend(value: entry.message, for: entry.typeString)
                     }
                 }
             }

--- a/Sources/git-cl/Commands/ReleasedCommand.swift
+++ b/Sources/git-cl/Commands/ReleasedCommand.swift
@@ -46,22 +46,21 @@ struct ReleasedCommand: ParsableCommand {
         var matchedRelease: Bool = false
 
         outerLoop: for changelogCommit: ChangelogCommit in self.changelogCommits {
+            if let commitRelease = changelogCommit.release {
+                if matchedRelease {
+                    break outerLoop
+                } else {
+                    releaseID = commitRelease
+                    releaseDate = changelogCommit.commit.date
+                    matchedRelease = (commitRelease == self.release)
+                    releaseCommits = []
+                    categorizedEntries = [:]
+                }
+            }
+
             if !changelogCommit.changelogEntries.isEmpty {
                 for entry in changelogCommit.changelogEntries {
-                    switch entry {
-                    case .release(let msg):
-                        if matchedRelease {
-                            break outerLoop
-                        } else {
-                            releaseID = msg
-                            releaseDate = changelogCommit.commit.date
-                            matchedRelease = (msg == self.release)
-                            releaseCommits = []
-                            categorizedEntries = [:]
-                        }
-                    default:
-                        categorizedEntries.upsertAppend(value: entry.message, for: entry.typeString)
-                    }
+                    categorizedEntries.upsertAppend(value: entry.message, for: entry.typeString)
                 }
             }
             releaseCommits.append(changelogCommit)

--- a/Sources/git-cl/Commands/UnreleasedCommand.swift
+++ b/Sources/git-cl/Commands/UnreleasedCommand.swift
@@ -37,14 +37,13 @@ struct UnreleasedCommand: ParsableCommand {
         var categorizedEntries: [OldChangelog.Category: [OldChangelog.Entry]] = [:]
 
         outerLoop: for changelogCommit: ChangelogCommit in self.changelogCommits {
+            if let _ = changelogCommit.release {
+                break outerLoop
+            }
+
             if !changelogCommit.changelogEntries.isEmpty {
                 for entry in changelogCommit.changelogEntries {
-                    switch entry {
-                    case .release(_):
-                        break outerLoop
-                    default:
-                        categorizedEntries.upsertAppend(value: entry.message, for: entry.typeString)
-                    }
+                    categorizedEntries.upsertAppend(value: entry.message, for: entry.typeString)
                 }
             }
 

--- a/Sources/git-cl/Models/ChangelogCommit.swift
+++ b/Sources/git-cl/Models/ChangelogCommit.swift
@@ -1,6 +1,16 @@
 import Foundation
 
 public struct ChangelogCommit {
+    private let releaseRegexPattern = #"^v?\d+\.\d+\.\d+$"#
     public let commit: Commit
     public let changelogEntries: [ChangelogEntry]
+
+    var release: String? {
+        for tag in self.commit.tags {
+            if tag.matches(releaseRegexPattern) {
+                return tag
+            }
+        }
+        return nil
+    }
 }

--- a/Sources/git-cl/Models/ChangelogEntry.swift
+++ b/Sources/git-cl/Models/ChangelogEntry.swift
@@ -1,7 +1,6 @@
 import Foundation
 
 public enum ChangelogEntry {
-    case release(String)
     case added(String)
     case changed(String)
     case deprecated(String)
@@ -15,7 +14,6 @@ public enum ChangelogEntry {
         case .changed: return "changed"
         case .deprecated: return "deprecated"
         case .fixed: return "fixed"
-        case .release: return "release"
         case .removed: return "removed"
         case .security: return "security"
         }
@@ -27,7 +25,6 @@ public enum ChangelogEntry {
         case .changed(let msg): return msg
         case .deprecated(let msg): return msg
         case .fixed(let msg): return msg
-        case .release(let msg): return msg
         case .removed(let msg): return msg
         case .security(let msg): return msg
         }


### PR DESCRIPTION
I did this because we found there were issues with releases being
identified by information in the commit message body. For example if a
release: v1.2.3 was included in a commit message body and then that
commit was cherry picked to another branch. Should that other branch
have the release v1.2.3. The answer is know and it breaks things. So, we
thought about it more and decided the correct thing to do was switch to
tags matching the pattern of ^v?\d+\.\d+\.\d+$ identifying a releases.
Tags that don't match that pattern are just ignored.

[changelog]
removed: 'release' commit message body entries as supported entry types
changed: to identify releases by Git tags matching pattern: ^v?\d+\.\d+\.\d+$

ps-id: F6FED912-DE05-48AB-89A4-AB5E88DFFF01