### PR TITLE
Switch ChangelogCommit.release to method

### DIFF
--- a/Sources/git-cl/Commands/FullCommand.swift
+++ b/Sources/git-cl/Commands/FullCommand.swift
@@ -44,7 +44,7 @@ struct FullCommand: ParsableCommand {
 
         for changelogCommit: ChangelogCommit in self.changelogCommits {
             // if it is release
-            if let release = changelogCommit.release {
+            if let release = changelogCommit.release() {
                 // track release shas for generating link references at the end
                 if let releaseID = releaseID, let _ = releaseDate, let releaseSha = releaseSha {
                     versionShas.append((releaseID, releaseSha, changelogCommit.commit.sha))

--- a/Sources/git-cl/Commands/LatestCommand.swift
+++ b/Sources/git-cl/Commands/LatestCommand.swift
@@ -39,7 +39,7 @@ struct LatestCommand: ParsableCommand {
         var releaseDate: Date?
 
         outerLoop: for changelogCommit: ChangelogCommit in self.changelogCommits {
-            if let release = changelogCommit.release {
+            if let release = changelogCommit.release() {
                 if releaseID != nil {
                     break outerLoop
                 } else {

--- a/Sources/git-cl/Commands/ReleasedCommand.swift
+++ b/Sources/git-cl/Commands/ReleasedCommand.swift
@@ -46,7 +46,7 @@ struct ReleasedCommand: ParsableCommand {
         var matchedRelease: Bool = false
 
         outerLoop: for changelogCommit: ChangelogCommit in self.changelogCommits {
-            if let commitRelease = changelogCommit.release {
+            if let commitRelease = changelogCommit.release() {
                 if matchedRelease {
                     break outerLoop
                 } else {

--- a/Sources/git-cl/Commands/UnreleasedCommand.swift
+++ b/Sources/git-cl/Commands/UnreleasedCommand.swift
@@ -37,7 +37,7 @@ struct UnreleasedCommand: ParsableCommand {
         var categorizedEntries: [OldChangelog.Category: [OldChangelog.Entry]] = [:]
 
         outerLoop: for changelogCommit: ChangelogCommit in self.changelogCommits {
-            if let _ = changelogCommit.release {
+            if let _ = changelogCommit.release() {
                 break outerLoop
             }
 

--- a/Sources/git-cl/Models/ChangelogCommit.swift
+++ b/Sources/git-cl/Models/ChangelogCommit.swift
@@ -5,7 +5,7 @@ public struct ChangelogCommit {
     public let commit: Commit
     public let changelogEntries: [ChangelogEntry]
 
-    var release: String? {
+    public func release() -> String? {
         for tag in self.commit.tags {
             if tag.matches(releaseRegexPattern) {
                 return tag


### PR DESCRIPTION
I did this because I am going to need to be able to pass a parameter to
it to support including pre-release tags. This change just prepares me
to be able to do that in a following commit.

ps-id: EAF47B0D-F6E9-40A5-8B93-8652A2182123