### PR TITLE
Add -p option to include pre-release releases

### DIFF
--- a/Sources/git-cl/Commands/ReleasedCommand.swift
+++ b/Sources/git-cl/Commands/ReleasedCommand.swift
@@ -5,6 +5,7 @@ struct ReleasedCommand: ParsableCommand {
     enum CodingKeys: String, CodingKey {
         case commits = "commits"
         case release = "release"
+        case pre = "pre"
     }
 
     private let git: GitShell
@@ -21,6 +22,9 @@ struct ReleasedCommand: ParsableCommand {
     @Flag(name: .shortAndLong, help: "Generate a list of released commits")
     var commits: Bool
 
+    @Flag(name: .shortAndLong, help: "Include pre-releases in the output")
+    var pre: Bool
+
     @Argument(help: "The release id")
     var release: String
 
@@ -34,6 +38,7 @@ struct ReleasedCommand: ParsableCommand {
         self.changelogCommits = ChangelogCommits(commits: try! self.git.commits())
         let container = try decoder.container(keyedBy: CodingKeys.self)
         self.commits = try container.decode(Bool.self, forKey: .commits)
+        self.pre = try container.decode(Bool.self, forKey: .pre)
         self.release = try container.decode(String.self, forKey: .release)
     }
     
@@ -46,7 +51,7 @@ struct ReleasedCommand: ParsableCommand {
         var matchedRelease: Bool = false
 
         outerLoop: for changelogCommit: ChangelogCommit in self.changelogCommits {
-            if let commitRelease = changelogCommit.release() {
+            if let commitRelease = changelogCommit.release(self.pre) {
                 if matchedRelease {
                     break outerLoop
                 } else {

--- a/Sources/git-cl/Commands/UnreleasedCommand.swift
+++ b/Sources/git-cl/Commands/UnreleasedCommand.swift
@@ -4,6 +4,7 @@ import ArgumentParser
 struct UnreleasedCommand: ParsableCommand {
     enum CodingKeys: String, CodingKey {
         case commits = "commits"
+        case pre = "pre"
     }
 
     private let git: GitShell
@@ -19,6 +20,9 @@ struct UnreleasedCommand: ParsableCommand {
     
     @Flag(name: .shortAndLong, help: "Generate a list of unreleased commits")
     var commits: Bool
+
+    @Flag(name: .shortAndLong, help: "Include pre-releases in the output")
+    var pre: Bool
     
     init() {
         self.git = try! GitShell(bash: Bash())
@@ -31,13 +35,14 @@ struct UnreleasedCommand: ParsableCommand {
 
         let container = try decoder.container(keyedBy: CodingKeys.self)
         self.commits = try container.decode(Bool.self, forKey: .commits)
+        self.pre = try container.decode(Bool.self, forKey: .pre)
     }
     
     func run() throws {
         var categorizedEntries: [OldChangelog.Category: [OldChangelog.Entry]] = [:]
 
         outerLoop: for changelogCommit: ChangelogCommit in self.changelogCommits {
-            if let _ = changelogCommit.release() {
+            if let _ = changelogCommit.release(self.pre) {
                 break outerLoop
             }
 

--- a/Sources/git-cl/Models/ChangelogCommit.swift
+++ b/Sources/git-cl/Models/ChangelogCommit.swift
@@ -2,15 +2,24 @@ import Foundation
 
 public struct ChangelogCommit {
     private let releaseRegexPattern = #"^v?\d+\.\d+\.\d+$"#
+    private let releaseOrPreReleaseRegexPattern = #"^v?\d+\.\d+\.\d+(-[0-9A-Za-z-\.]+)?$"#
     public let commit: Commit
     public let changelogEntries: [ChangelogEntry]
 
-    public func release() -> String? {
+    public func release(_ includePreReleases: Bool = false) -> String? {
         for tag in self.commit.tags {
-            if tag.matches(releaseRegexPattern) {
+            if tag.matches(regexPattern(includePreReleases)) {
                 return tag
             }
         }
         return nil
+    }
+
+    private func regexPattern(_ includePreReleases: Bool) -> String {
+        if includePreReleases {
+            return releaseOrPreReleaseRegexPattern
+        } else {
+            return releaseRegexPattern
+        }
     }
 }


### PR DESCRIPTION
I did this to support users that use semantic versioning based
pre-releases and wanted to be able to have git-cl match pre-releases as
well as normal releases.

[changelog]
added: -p option to include pre-release releases

ps-id: 7A2AAC2B-1E7C-44B4-A2BB-A1102859E092