### PR TITLE
Fix crash when in repo without a repo url

### DIFF
--- a/Sources/git-cl/Commands/FullCommand.swift
+++ b/Sources/git-cl/Commands/FullCommand.swift
@@ -99,14 +99,18 @@ struct FullCommand: ParsableCommand {
         }
 
         // print the link references
-        let compareBaseURL = self.repositoryURL()!
-        versionShas.forEach { versionShaInfo in
-            print("[\(versionShaInfo.0)]: \(compareBaseURL.absoluteString)/compare/\(versionShaInfo.2.prefix(7))...\(versionShaInfo.1.prefix(7))")
+        if let compareBaseURL = self.repositoryURL() {
+            versionShas.forEach { versionShaInfo in
+                print("[\(versionShaInfo.0)]: \(compareBaseURL.absoluteString)/compare/\(versionShaInfo.2.prefix(7))...\(versionShaInfo.1.prefix(7))")
+            }
         }
     }
 
     private func repositoryURL() -> URL? {
-        let urlString = try! self.git.findRespoitoryOriginURL()!.absoluteString
-        return URL(string: urlString.replacingOccurrences(of: ":", with: "/").replacingOccurrences(of: "git@", with: "https://"))
+        if let urlString = try? self.git.findRespoitoryOriginURL()?.absoluteString {
+            return URL(string: urlString.replacingOccurrences(of: ":", with: "/").replacingOccurrences(of: "git@", with: "https://"))
+        } else {
+            return nil
+        }
     }
 }


### PR DESCRIPTION
I did this because when you would use the full sub-command in a repo
that didn't have a base repo url set it would crash. That is a horrible
experience. So instead now it safely degrades back to a mode without the
link references at the bottom of the Changelog output.

[changelog]
fixed: crash when repo doesn't have a repo url

ps-id: CFB4BAF9-04D1-490F-A1A4-00D7653DFFD3