### PR TITLE
Add support for case-insensitive [changelog] matching

### DIFF
--- a/Sources/git-cl/Actions/ChangelogCommits.swift
+++ b/Sources/git-cl/Actions/ChangelogCommits.swift
@@ -11,6 +11,7 @@ public struct ChangelogCommits: Sequence {
 public struct ChangelogCommitsIterator: IteratorProtocol {
     private let changelogCommits: ChangelogCommits
     private var commitsIterator: CommitsIterator
+    private let changelogPattern = #"\[changelog\]"#
     private let regexPattern = #"(added|changed|deprecated|removed|fixed|security):\w?(.*)"#
 
     init(_ changelogCommits: ChangelogCommits) {
@@ -23,10 +24,15 @@ public struct ChangelogCommitsIterator: IteratorProtocol {
             guard let body = commit.body else {
                 return ChangelogCommit(commit: commit, changelogEntries: [])
             }
+            
+            var changelogKey = "[changelog]"
+            if let changelogRange = body.range(of: changelogPattern, options: [.regularExpression, .caseInsensitive]) {
+                changelogKey = String(body[changelogRange])
+            }
 
             let changelogBody = body
                 .trimmingCharacters(in: .whitespacesAndNewlines)
-                .components(separatedBy: "[changelog]")
+                .components(separatedBy: changelogKey)
                 .dropFirst()
                 .joined(separator: "\n")
                 .trimmingCharacters(in: .whitespacesAndNewlines)

--- a/Tests/GitCLTests/GitCLTests.swift
+++ b/Tests/GitCLTests/GitCLTests.swift
@@ -2,21 +2,28 @@ import XCTest
 import Foundation
 
 final class GitCLTests: XCTestCase {
-    func regexTest() throws {
+    func testRegex() throws {
+        let changelogPattern = #"\[changelog\]"#
         let regexPattern = #"(added|changed|deprecated|removed|fixed|security)(?-i):\w?(.*)"#
         
         let body = """
         This is a commit Summary
 
         This is the message
-        [changelog]
+        [CHANGELOG]
         added: ONE THING
         ADDED: Another Thing
         Added: Seomthing
         """
+        
+        var changelogKey = "[changelog]"
+        if let changelogRange = body.range(of: changelogPattern, options: [.regularExpression, .caseInsensitive]) {
+            changelogKey = String(body[changelogRange])
+        }
+        
         let changelogBody = body
             .trimmingCharacters(in: .whitespacesAndNewlines)
-            .components(separatedBy: "[changelog]")
+            .components(separatedBy: changelogKey)
             .dropFirst()
             .joined(separator: "\n")
             .trimmingCharacters(in: .whitespacesAndNewlines)
@@ -59,6 +66,6 @@ final class GitCLTests: XCTestCase {
     }
 
     static var allTests = [
-        ("regexTest", regexTest),
+        ("testRegex", testRegex),
     ]
 }


### PR DESCRIPTION
This implements a regex-based approach of finding the [changelog]
separator.

[changelog]
added: Added support for case-insensitive searching for the [changelog]

ps-id: 26182CAE-DEB0-4CBF-BCCE-8535F8C2C77D