### PR TITLE
Remove dependency on v2.25.0

### DIFF
--- a/Sources/GitChangelog/GitShell.swift
+++ b/Sources/GitChangelog/GitShell.swift
@@ -121,7 +121,7 @@ public class GitShell {
     }
 
     public func commits(for tag: Tag)throws -> Commits {
-        let result = try run(self.path, arguments: ["--no-pager", "log", "--pretty=format:----GIT-CHANGELOG-COMMIT-BEGIN----%n%H%n%d%n%as%n%B", tag])
+        let result = try run(self.path, arguments: ["--no-pager", "log", "--date=short", "--pretty=format:----GIT-CHANGELOG-COMMIT-BEGIN----%n%H%n%d%n%cd%n%B", tag])
         guard result.isSuccessful else { throw Error.gitLogFailure }
         guard let output = result.standardOutput else { return Commits(formattedGitLogOutput: "") }
 
@@ -129,7 +129,7 @@ public class GitShell {
     }
 
     public func commits() throws -> Commits {
-        let result = try run(self.path, arguments: ["--no-pager", "log", "--pretty=format:----GIT-CHANGELOG-COMMIT-BEGIN----%n%H%n%d%n%as%n%B"])
+        let result = try run(self.path, arguments: ["--no-pager", "log", "--date=short", "--pretty=format:----GIT-CHANGELOG-COMMIT-BEGIN----%n%H%n%d%n%cd%n%B"])
         guard result.isSuccessful else { throw Error.gitLogFailure }
         guard let output = result.standardOutput else { return Commits(formattedGitLogOutput: "") }
         


### PR DESCRIPTION
There was previously a dependency on v2.25.0 and greater because we were
using the %as pretty format option in our git log commands. Any user
that attempted to use git-cl with a previous version of Git would end up
with a crash.

This commit addresses this issue by switching to a pretty format
argument that at least goes back to Git v2.2.3 if not even further.
Specifically we switched to the %cd pretty formatter option which says
to include the commit date in the format described by the `--date`
option. In our case we use `--date=short` which results in YYYY-MM-DD
format which is what we were getting before from %as.

I believe switching to the commit date vs the author date is also more
accurate in terms of representing when things were introduced into the
Git tree rather than when someone originally authored some code.

[changelog]
fixed: crash when used with Git versions prior to v2.25.0

ps-id: 496A509F-190A-49C7-8D07-F849DBED1F7B