### PR TITLE
Add CI workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,42 @@
+name: Run Tests
+
+on: [push]
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: fwal/setup-swift@v1
+        with:
+          swift-version: "5.2"
+
+      - name: Build
+        run: swift build
+
+      - name: Test
+        run: swift test
+
+  example:
+    runs-on: ubuntu-latest
+    needs: tests
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0  # needed to get full history
+      - uses: fwal/setup-swift@v1
+        with:
+          swift-version: "5.2"
+      - name: Install git-ci
+        run: |
+          cd /tmp/
+          git clone https://github.com/uptech/git-cl.git git-cl
+          cd ./git-cl
+          make -j$(nproc)
+          sudo make install
+          cd -
+      - name: Generate Changelog
+        run: |
+          git cl full

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -1,6 +1,6 @@
 import XCTest
 
-import git_changelogTests
+import GitCLTests
 
 var tests = [XCTestCaseEntry]()
 tests += GitCLTests.allTests()


### PR DESCRIPTION
## Changes
- Added CI workflow for GitHub to run tests
- Added CI workflow for GitHub to build & run tool as "external" user
- Fixed test import for Linux

## Example
An example of a successful build can be found [here](https://github.com/Green-Edge/git-cl/actions/runs/496132887).

## Notes
It seems that as of this build it looks like recent changes have resolved #44 